### PR TITLE
remove recursively append to c(); not tested

### DIFF
--- a/R/ess.R
+++ b/R/ess.R
@@ -14,15 +14,9 @@ local_ess <- function(x, chains) {
 
 
 all_local_ess <- function(chains, max_nb_points = 500) {
-    tab_rhat <- c()
     grid <- grid_for_R(chains, max_nb_points)
-    for (x in grid) {
-        if (!is.na(local_ess(x, chains))){
-            ess_x <- local_ess(x, chains)
-        }
-        tab_rhat <- c(tab_rhat, ess_x)
-    }
-    return(tab_rhat)
+    tab_rhat <- sapply(grid, function(x) local_ess(x, chains))
+    return(tab_rhat[!is.na(tab_rhat)])
 }
 
 ess_infinity <- function(chains, dir = NULL, max_nb_points = 500) {

--- a/R/infinity_rhat.R
+++ b/R/infinity_rhat.R
@@ -131,8 +131,8 @@ rhat_infinity_max_directions <- function(chains,
 
     dim_params = dim(chains)[2]
 
-    # Vector that will contains the different R-hat infinity:
-    directed_rhat_inf = c()
+    # max R-hat infinity:
+    directed_rhat_inf <- -Inf
 
     # Vector with the ids of the different directions:
     directions_idx = 0:(2^(dim_params - 1) - 1)
@@ -141,14 +141,13 @@ rhat_infinity_max_directions <- function(chains,
     if (!is.null(nb_directions)) {
         directions_idx = sample(directions_idx, nb_directions, replace = F)
     }
-    for (i in directions_idx) {
 
+    for (i in seq_along(directions_idx)) {
         directions = as.integer(intToBits(i))
-
-        directed_rhat_inf = c(directed_rhat_inf, rhat_infinity(chains, directions, max_nb_points))
-
+        rhat_inf <- rhat_infinity(chains, directions, max_nb_points)
+        if (rhat > directed_rhat_inf) {
+            directed_rhat_inf <- rhat
+        }
     }
-    return(max(directed_rhat_inf))
+    return(directed_rhat_inf)
 }
-
-

--- a/R/multivariate_rhat.R
+++ b/R/multivariate_rhat.R
@@ -41,9 +41,9 @@
 #'
 multivariate_local_rhat <- function(x, chains) {
     dim_ch <- dim(chains)
-    bool_ch <- c()
+    bool_ch <- rep(NA, dim_ch[3])
     for (ch_id in 1:dim_ch[3]) {
-        bool_ch <- c(bool_ch, apply(t(t(chains[, , ch_id]) <= x), 1, all))
+        bool_ch[ch_id] <- apply(t(t(chains[, , ch_id]) <= x), 1, all)
     }
     return (trad_rhat(array(bool_ch, c(dim_ch[1], dim_ch[3]))))
 }
@@ -131,19 +131,19 @@ multivariate_grid_for_R <- function(chains, max_nb_points = 500) {
 #'
 multivariate_directed_local_rhat <- function(x, chains, dir) {
     dim_ch <- dim(chains)
-    bool_ch = c()
+    bool_ch = rep(NA, dim_ch[3])
     for (ch_id in 1:dim_ch[3]) {
-        tmp_ind = c()
+        tmp_ind = rep(NA, dim_ch[2])
         for (dim_id in 1:dim_ch[2]) {
             if (dir[dim_id] == 1) {
-                tmp_ind = c(tmp_ind, chains[, dim_id, ch_id] >= x[dim_id])
+                tmp_ind[dim_id] = chains[, dim_id, ch_id] >= x[dim_id]
             } else {
-                tmp_ind = c(tmp_ind, chains[, dim_id, ch_id] <= x[dim_id])
+                tmp_ind[dim_id] = chains[, dim_id, ch_id] <= x[dim_id]
             }
         }
         tmp_ch = array(tmp_ind, c(dim_ch[1], dim_ch[2]))
 
-        bool_ch = c(bool_ch, apply(tmp_ch, 1, all))
+        bool_ch[ch_id] = apply(tmp_ch, 1, all)
     }
     return (trad_rhat(array(bool_ch, c(dim_ch[1], dim_ch[3]))))
 }
@@ -179,13 +179,13 @@ multivariate_directed_local_rhat <- function(x, chains, dir) {
 #'
 #'
 multivariate_all_local_rhat <- function(chains, dir = NULL, max_nb_points = 500) {
-    tab_rhat = c()
     grid = multivariate_grid_for_R(chains, max_nb_points)
+    tab_rhat = rep(NA, dim(grid)[1])
     for (i in 1:dim(grid)[1]) {
         if (is.null(dir)) {
-            tab_rhat = c(tab_rhat, multivariate_local_rhat(grid[i, ], chains))
+            tab_rhat[i] = multivariate_local_rhat(grid[i, ], chains)
         } else {
-            tab_rhat = c(tab_rhat, multivariate_directed_local_rhat(grid[i, ], chains, dir))
+            tab_rhat[i] = multivariate_directed_local_rhat(grid[i, ], chains, dir)
         }
     }
     return(tab_rhat)

--- a/R/plot_r_inf.R
+++ b/R/plot_r_inf.R
@@ -95,31 +95,33 @@ plot_hist <- function(R_matrix, colors = c("red", "blue", "green", "yellow"),
     abline(v=threshold, lty=2, lwd=4)
   }
 
-  r_exp = c()
-  for (i in 1:length(r_names)){
+  I <- length(r_names)
+  r_exp <- rep(NA, I)
+
+  for (i in 1:I){
     if (!is.expression(r_names[i])){
       if (r_names[i] == "R-hat"){
-        r_exp = c(r_exp, expression(italic(hat(R))))
+        r_exp[i] = expression(italic(hat(R)))
       }
     }
     if (!is.expression(r_names[i])) {
       if (r_names[i] == "Rank-R-hat"){
-        r_exp = c(r_exp, expression(italic(Rank-hat(R))))
+        r_exp[i] = expression(italic(Rank-hat(R)))
       }
     }
     if (!is.expression(r_names[i])) {
       if (r_names[i] == "Brooks Multivariate R-hat"){
-        r_exp = c(r_exp, expression(italic(hat(R))))
+        r_exp[i] = expression(italic(hat(R)))
       }
     }
     if (!is.expression(r_names[i])) {
       if (r_names[i] == "R-hat-infinity"){
-        r_exp = c(r_exp, expression(italic(hat(R)[infinity])))
+        r_exp[i] = expression(italic(hat(R)[infinity]))
       }
     }
     if (!is.expression(r_names[i])) {
       if (r_names[i] == "max-R-hat"){
-        r_exp = c(r_exp, expression(italic(max-hat(R)[infinity])))
+        r_exp[i] = expression(italic(max-hat(R)[infinity]))
       }
     }
   }
@@ -132,4 +134,3 @@ plot_hist <- function(R_matrix, colors = c("red", "blue", "green", "yellow"),
     }
   }
 }
-

--- a/R/theoretical_R.R
+++ b/R/theoretical_R.R
@@ -18,14 +18,12 @@ local_r_dist <- function(x, dists){
 }
 
 r_dist_values <- function(npoints, xlim, dists){
-  values <- c()
   grid <- seq(xlim[1], xlim[2], length.out = npoints)
   theoretical_r <- unlist(lapply(grid, (function(x) local_r_dist(x, dists))))
   return(array(c(grid, theoretical_r), c(npoints,2)))
 }
 
 max_r_dist_bivariate <- function(npoints, xlim, dists){
-  values <- c()
   grid1 <- seq(xlim[1], xlim[2], length.out = npoints)
   grid2 <- seq(xlim[1], xlim[2], length.out = npoints)
   max_r = 0

--- a/R/univariate_rhat.R
+++ b/R/univariate_rhat.R
@@ -165,10 +165,7 @@ grid_for_R <- function(chains, max_nb_points = 500) {
 #' #              xlim = c(-1, 1), ylim=c(0.999,1.1), title ="Gaussian distributions")
 #'
 all_local_rhat <- function(chains, max_nb_points = 500) {
-    tab_rhat <- c()
     grid <- grid_for_R(chains, max_nb_points)
-    for (x in grid) {
-        tab_rhat <- c(tab_rhat, local_rhat(x, chains))
-    }
+    tab_rhat <- sapply(grid, function(x) local_rhat(x, chains))
     return(tab_rhat)
 }


### PR DESCRIPTION
Thanks for a great talk today at Bob's reading group.

This pull request replaces the following pattern

```
tmp <- c()
for (i in 1:I) {
    tmp <- c(tmp, f(...))
}
return(temp)
```

which is computationally unfriendly, with things like

```
tmp <- rep(NA, I)
for (i in 1:I) {
    tmp[i] <- f(...)
}
return(tmp)
```

which pre-allocates memory once and reuses it.

This code is not tested.
